### PR TITLE
Add Dependabot auto-merge workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yml
+++ b/.github/workflows/dependabot-automerge.yml
@@ -1,0 +1,31 @@
+name: Dependabot auto-merge
+
+# Enables GitHub native auto-merge on Dependabot PRs. Once the required status
+# checks on `main` pass, GitHub squash-merges the PR automatically. This relies
+# on branch protection requiring CI checks — without required checks, auto-merge
+# has nothing to wait on and would error with "Pull request is in clean status".
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Merge everything that passes CI. To restrict to patch/minor only, add to
+      # the condition below, e.g.:
+      #   if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds `.github/workflows/dependabot-automerge.yml` so Dependabot PRs merge themselves once CI passes — same setup just applied to IOStructs.jl, prompted by #11.

## How it works
- Triggers on `pull_request_target` for PRs opened by `dependabot[bot]`.
- Fetches Dependabot metadata, then enables GitHub **native auto-merge** (`gh pr merge --auto --squash --delete-branch`).
- GitHub completes the squash-merge automatically once the required CI status check on `main` goes green.

## Branch protection (already configured)
`main` now requires the **`Julia 1`** status check. The **`Julia nightly`** job is intentionally **not** required — nightly Julia breaks routinely and requiring it would block all merges. Native auto-merge needs at least one required check to wait on.

## Notes
- Currently merges **all** Dependabot updates that pass the required check. To restrict to patch/minor, gate on `steps.metadata.outputs.update-type` (example commented in the workflow).
- Must land on `main` to take effect.